### PR TITLE
Batman 2339

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1389,8 +1389,6 @@ class ServiceNowAlerter(Alerter):
         super(ServiceNowAlerter, self).__init__(rule)
         self.servicenow_rest_url = self.rule['servicenow_rest_url']
         self.servicenow_proxy = self.rule.get('servicenow_proxy', None)
-        self.service_offering = self.rule.get('service_offering', None)
-        self.u_second_class = self.rule.get('u_second_class', None)
 
     def alert(self, matches):
         for match in matches:

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1389,6 +1389,8 @@ class ServiceNowAlerter(Alerter):
         super(ServiceNowAlerter, self).__init__(rule)
         self.servicenow_rest_url = self.rule['servicenow_rest_url']
         self.servicenow_proxy = self.rule.get('servicenow_proxy', None)
+        self.service_offering = self.rule.get('service_offering', None)
+        self.u_second_class = self.rule.get('u_second_class', None)
 
     def alert(self, matches):
         for match in matches:
@@ -1415,7 +1417,9 @@ class ServiceNowAlerter(Alerter):
             "u_originating_group": self.rule["u_originating_group"],
             "u_division": self.rule["u_division"],
             "contact_type": self.rule["contact_type"],
-            "opened_by": self.rule["opened_by"]
+            "opened_by": self.rule["opened_by"],
+            "service_offering": self.rule["service_offering"],
+            "u_second_class": self.rule["u_second_class"]
         }
         try:
             response = requests.post(


### PR DESCRIPTION
Dev team requested the addition of 2 new fields on the payload of Service Now alerts
These fields were added into the payload and the cards were generated
https://ccdev.service-now.com/incident.do?sys_id=55f858a81b2d1410eab2ececbc4bcb1c&sysparm_view=default+view&sysparm_view_forced=true
https://ccdev.service-now.com/incident.do?sys_id=ff89d0a81be11410ea50433fbd4bcb49&sysparm_view=default+view&sysparm_view_forced=true
No changes were required at ihm-alert side
Alert used during the tests

test.zip
https://jenkins.x1-nonprod.iheartmedia.com/job/ihm-alert/job/deploy-env/298/console